### PR TITLE
Set a hostname for the VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,9 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 80, host: 8088    # Django front-end
     config.vm.network :forwarded_port, guest: 8080, host: 8089  # Expt runner
 
+    # This needs to look real enough for git to set a default identity
+    config.vm.hostname = "weblab.local"
+
     config.vm.provider "virtualbox" do |vb|
         vb.name = "WebLab"
         vb.memory = "4096"


### PR DESCRIPTION
The `git notes` command needs to be able to fake a git identity, which requires a real-looking hostname.