### PR TITLE
Temporary fitting code

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,8 @@ Vagrant.configure("2") do |config|
         ansible.raw_arguments = ['--vault-id', 'dev@dev-vault-pw']
 
         ansible.extra_vars = {
-            django_git_branch: 'master'
+            django_git_branch: 'master',
+            celery_git_branch: 'fitting',
         }
 
         ansible.verbose = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
         ansible.raw_arguments = ['--vault-id', 'dev@dev-vault-pw']
 
         ansible.extra_vars = {
-            django_git_branch: 'master',
+            django_git_branch: 'fitting',
             celery_git_branch: 'fitting',
         }
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,8 +30,8 @@ Vagrant.configure("2") do |config|
         ansible.raw_arguments = ['--vault-id', 'dev@dev-vault-pw']
 
         ansible.extra_vars = {
-            django_git_branch: 'fitting',
-            celery_git_branch: 'fitting',
+            django_git_branch: 'master',
+            celery_git_branch: 'master',
         }
 
         ansible.verbose = true

--- a/group_vars/production/vars.yml
+++ b/group_vars/production/vars.yml
@@ -2,8 +2,8 @@
 
 # Production runs from master branches by default
 
-django_git_branch: fitting
-celery_git_branch: fitting
+django_git_branch: master
+celery_git_branch: master
 
 # Django secrets
 django_db_pass: '{{ vault_django_db_pass }}'

--- a/group_vars/production/vars.yml
+++ b/group_vars/production/vars.yml
@@ -3,7 +3,7 @@
 # Production runs from master branches by default
 
 django_git_branch: fitting
-celery_git_branch: master
+celery_git_branch: fitting
 
 # Django secrets
 django_db_pass: '{{ vault_django_db_pass }}'

--- a/group_vars/production/vars.yml
+++ b/group_vars/production/vars.yml
@@ -2,7 +2,7 @@
 
 # Production runs from master branches by default
 
-django_git_branch: master
+django_git_branch: fitting
 celery_git_branch: master
 
 # Django secrets

--- a/roles/celery/templates/config.json.j2
+++ b/roles/celery/templates/config.json.j2
@@ -11,6 +11,9 @@
     "environment": {
         "comment": "Environment variables used when running the backend executable; other settings are inherited from the webserver environment.",
         "LD_LIBRARY_PATH": "{{ chaste_ld_library_path }}",
+        "CHASTE_ROOT": "{{ chaste_root }}",
+        "FC_ROOT": "{{ fc_root }}",
+        "AD_ROOT": "{{ fitting_prototype_root }}",
         "CHASTE_TEST_OUTPUT": "/tmp/fc_webservice_testoutput",
         "USER": "{{ celery_user }}",
         "GROUP": "{{ user_meta[celery_user].group }}",

--- a/roles/celery/templates/config.json.j2
+++ b/roles/celery/templates/config.json.j2
@@ -2,6 +2,7 @@
     "password": "{{ fc_webservice_password }}",
     "chaste_root": "{{ chaste_root }}",
     "exe_path": "{{ chaste_fc_exe }}",
+    "fitting_path": "{{ fitting_exe }}",
     "syntax_check_path": "{{ chaste_syntax_exe }}",
     "temp_dir": "/tmp/",
     "temp_file_prefix": "fc_tmp_",

--- a/roles/celery/templates/config.json.j2
+++ b/roles/celery/templates/config.json.j2
@@ -13,7 +13,6 @@
         "LD_LIBRARY_PATH": "{{ chaste_ld_library_path }}",
         "CHASTE_ROOT": "{{ chaste_root }}",
         "FC_ROOT": "{{ fc_root }}",
-        "AD_ROOT": "{{ fitting_prototype_root }}",
         "CHASTE_TEST_OUTPUT": "/tmp/fc_webservice_testoutput",
         "USER": "{{ celery_user }}",
         "GROUP": "{{ user_meta[celery_user].group }}",

--- a/roles/celery/templates/config.json.j2
+++ b/roles/celery/templates/config.json.j2
@@ -3,6 +3,7 @@
     "chaste_root": "{{ chaste_root }}",
     "exe_path": "{{ chaste_fc_exe }}",
     "fitting_path": "{{ fitting_exe }}",
+    "fitting_virtualenv": "{{ fc_virtualenv }}",
     "syntax_check_path": "{{ chaste_syntax_exe }}",
     "temp_dir": "/tmp/",
     "temp_file_prefix": "fc_tmp_",

--- a/roles/fc-backend/defaults/main.yml
+++ b/roles/fc-backend/defaults/main.yml
@@ -15,3 +15,9 @@ fc_root: "{{ chaste_root }}/projects/{{ fc_project_name }}"
 chaste_fc_exe: "{{ fc_root }}/apps/src/FunctionalCuration"
 
 chaste_version: 0ff3ad0a2d3bdba18b5e615f6b8d5d93ed1fc7db
+
+# FC fitting prototype
+fitting_prototype_repo: https://github.com/ModellingWebLab/chaste-project-fitting-pints.git
+fitting_prototype_project_name: "AidanDaly"
+fitting_prototype_root: "{{ chaste_root }}/projects/{{ aidan_project_name }}"
+fitting_exe: "{{ fitting_prototype_root }}/weblab/cardiac.py"

--- a/roles/fc-backend/defaults/main.yml
+++ b/roles/fc-backend/defaults/main.yml
@@ -20,4 +20,4 @@ chaste_version: 0ff3ad0a2d3bdba18b5e615f6b8d5d93ed1fc7db
 fitting_prototype_repo: https://github.com/ModellingWebLab/chaste-project-fitting-pints.git
 fitting_prototype_project_name: "AidanDaly"
 fitting_prototype_root: "{{ chaste_root }}/projects/{{ fitting_prototype_project_name }}"
-fitting_exe: "{{ fitting_prototype_root }}/weblab/cardiac.py"
+fitting_exe: "{{ fitting_prototype_root }}/cardiac.py"

--- a/roles/fc-backend/defaults/main.yml
+++ b/roles/fc-backend/defaults/main.yml
@@ -20,4 +20,4 @@ chaste_version: 0ff3ad0a2d3bdba18b5e615f6b8d5d93ed1fc7db
 fitting_prototype_repo: https://github.com/ModellingWebLab/chaste-project-fitting-pints.git
 fitting_prototype_project_name: "AidanDaly"
 fitting_prototype_root: "{{ chaste_root }}/projects/{{ fitting_prototype_project_name }}"
-fitting_exe: "{{ fitting_prototype_root }}/cardiac.py"
+fitting_exe: "{{ fitting_prototype_root }}/service.sh"

--- a/roles/fc-backend/defaults/main.yml
+++ b/roles/fc-backend/defaults/main.yml
@@ -19,5 +19,5 @@ chaste_version: 0ff3ad0a2d3bdba18b5e615f6b8d5d93ed1fc7db
 # FC fitting prototype
 fitting_prototype_repo: https://github.com/ModellingWebLab/chaste-project-fitting-pints.git
 fitting_prototype_project_name: "AidanDaly"
-fitting_prototype_root: "{{ chaste_root }}/projects/{{ aidan_project_name }}"
+fitting_prototype_root: "{{ chaste_root }}/projects/{{ fitting_prototype_project_name }}"
 fitting_exe: "{{ fitting_prototype_root }}/weblab/cardiac.py"

--- a/roles/fc-backend/tasks/main.yml
+++ b/roles/fc-backend/tasks/main.yml
@@ -81,14 +81,7 @@
         - numexpr
         - matplotlib<2
         - lxml
-
-    - name: FC | Install Pints from GitHub
-      pip:
-        name: git+https://github.com/pints-team/pints.git
-        state: present
-        virtualenv: '{{ fc_virtualenv }}'
-        virtualenv_python: python2
-        virtualenv_site_packages: yes
+        - git+https://github.com/pints-team/pints.git
 
     - name: Stat FC exe
       stat:

--- a/roles/fc-backend/tasks/main.yml
+++ b/roles/fc-backend/tasks/main.yml
@@ -23,6 +23,7 @@
         - chaste-dependencies
         - scons
         - subversion
+        - python-numpy
 
 - name: Install Chaste & FunctionalCuration
   become: yes

--- a/roles/fc-backend/tasks/main.yml
+++ b/roles/fc-backend/tasks/main.yml
@@ -49,13 +49,23 @@
         force: yes
       register: code_fc
       notify: restart celery
-    
+
+    - name: Checkout Fitting prototype
+      git:
+        clone: yes
+        dest: '{{ fitting_prototype_root }}'
+        repo: '{{ fitting_prototype_repo }}'
+        version: 'master'
+        update: yes
+        force: yes
+      register: code_fitting_prototype
+
     - name: Default to ubuntu hostconfig for Chaste
       copy:
         dest: '{{ chaste_root }}/python/hostconfig/local.py'
         src: '{{ chaste_root }}/python/hostconfig/ubuntu.py'
         remote_src: yes
-    
+
     - name: FC | Install Python packages
       pip:
         name: '{{ item }}'
@@ -71,6 +81,14 @@
         - numexpr
         - matplotlib<2
         - lxml
+
+    - name: FC | Install Pints from GitHub
+      pip:
+        name: git+https://github.com/pints-team/pints.git
+        state: present
+        virtualenv: '{{ fc_virtualenv }}'
+        virtualenv_python: python2
+        virtualenv_site_packages: yes
 
     - name: Stat FC exe
       stat:


### PR DESCRIPTION
This branch allows temporary fitting code to be run, based on Aidan's original proof of concept

We can use this to demonstrate the idea of fitting on the web lab, but I don't believe the final version should be anything like this, so not for merging!

Main changes:

- Switch Django front-end to `fitting` branch (https://github.com/ModellingWebLab/WebLab/pull/173)
- Switch Celery task-runner to `fitting` branch (https://github.com/ModellingWebLab/fc-runner/pull/4)
- Add in python script to perform fitting (https://github.com/ModellingWebLab/chaste-project-fitting-pints), using PyCML / Chaste C++ back-end for functional curation