### PR TITLE
Upgrade node.js

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "roles/geerlingguy.postgresql"]
 	path = roles/geerlingguy.postgresql
 	url = https://github.com/geerlingguy/ansible-role-postgresql.git
+[submodule "roles/geerlingguy.nodejs"]
+	path = roles/geerlingguy.nodejs
+	url = https://github.com/geerlingguy/ansible-role-nodejs

--- a/roles/django/meta/main.yml
+++ b/roles/django/meta/main.yml
@@ -10,3 +10,6 @@ dependencies:
     user: '{{ django_user }}'
     virtualenv: '{{ django_virtualenv }}'
     virtualenv_command: pyvenv
+
+  # Ensure node is new enough (and installed)
+  - { role: geerlingguy.nodejs, become: yes }

--- a/roles/django/tasks/main.yml
+++ b/roles/django/tasks/main.yml
@@ -89,21 +89,6 @@
 
 # Build static files with gulp
 
-- name: gulp | Install node
-  apt:
-    name: "{{ item }}"
-    state: installed
-  with_items:
-    - npm
-    - nodejs-legacy
-  become: yes
-
-- name: gulp | Install gulp
-  command: npm install --global gulp-cli
-  args:
-    creates: /usr/local/bin/gulp
-  become: yes
-
 - name: gulp | Install node packages
   command: npm install
   args:
@@ -111,12 +96,27 @@
   become: yes
   become_user: "{{ django_user }}"
 
-- name: gulp | Build static assets
-  command: gulp
-  args:
-    chdir: "{{ django_static_path }}"
-  become: yes
-  become_user: "{{ django_user }}"
+- block:
+    - name: gulp | Build static assets
+      command: ./node_modules/gulp/bin/gulp.js
+      args:
+        chdir: "{{ django_static_path }}"
+      become: yes
+      become_user: "{{ django_user }}"
+  rescue:
+    # Errors are often due to a node upgrade
+    - name: gulp | Rebuild on npm/node version change
+      command: npm rebuild
+      args:
+        chdir: "{{ django_static_path }}"
+      become: yes
+      become_user: "{{ django_user }}"
+    - name: gulp | Rebuild static assets
+      command: ./node_modules/gulp/bin/gulp.js
+      args:
+        chdir: "{{ django_static_path }}"
+      become: yes
+      become_user: "{{ django_user }}"
 
 - name: Django | Collect static files
   django_manage:


### PR DESCRIPTION
In order to run gulp 4, needed to fix JS security holes (https://github.com/ModellingWebLab/WebLab/pull/196) we need a newer node.js than the default in Ubuntu. This PR causes the deployment to upgrade to the latest stable LTS v10.x node.js release.

Seems to run cleanly on my local Vagrant deploy.