### PR TITLE
Restart Django every night to avoid running out of file handles

### DIFF
--- a/roles/django/tasks/main.yml
+++ b/roles/django/tasks/main.yml
@@ -139,3 +139,4 @@
     weekday: "*"
     job: systemctl restart uwsgi
     state: present
+  become: yes

--- a/roles/django/tasks/main.yml
+++ b/roles/django/tasks/main.yml
@@ -126,3 +126,16 @@
     virtualenv: '{{ django_virtualenv }}'
   become: yes
   become_user: "{{ django_user }}"
+
+- name: Django | Ensure we restart every day to avoid git leaking file handles
+  cron:
+    cron_file: weblab
+    name: Restart Django
+    user: root
+    day: "*"
+    hour: 3
+    minute: 33
+    month: "*"
+    weekday: "*"
+    job: systemctl restart uwsgi
+    state: present


### PR DESCRIPTION
See https://gitpython.readthedocs.io/en/stable/intro.html#leakage-of-system-resources

Tested locally by setting the hour & minute to a time slightly in the future, and using `sudo journalctl -t weblab --since -10m` in the VM to check there was a uwsgi restart at the desired time, then checking the site was still live in the VM afterwards.