### PR TITLE
Reduce backend gateway timeouts

### DIFF
--- a/roles/fc-web-service/tasks/main.yml
+++ b/roles/fc-web-service/tasks/main.yml
@@ -17,6 +17,13 @@
     name: fcgiwrap
     state: present
 
+- name: fc-web-service | Configure fcgiwrap
+  template:
+    src: fcgiwrap.default.j2
+    dest: /etc/default/fcgiwrap
+    mode: 0644
+  notify: restart fcgiwrap
+
 - name: fc-web-service | Configure nginx
   become: yes
   import_role:

--- a/roles/fc-web-service/templates/fcgiwrap.default.j2
+++ b/roles/fc-web-service/templates/fcgiwrap.default.j2
@@ -1,0 +1,1 @@
+DAEMON_OPTS="-c {{ ansible_processor_vcpus | default(ansible_processor_count) }} -f"

--- a/roles/fc-web-service/vars/main.yml
+++ b/roles/fc-web-service/vars/main.yml
@@ -19,4 +19,7 @@ nginx_vhosts:
         include fastcgi_params;
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_FILENAME {{ fc_webservice_cgi_dir }}$fastcgi_script_name;
+        fastcgi_connect_timeout 75s; # This is typically the max possible according to nginx docs
+        fastcgi_read_timeout 120s;
+        fastcgi_send_timeout 120s;
       }


### PR DESCRIPTION
Fix #24 (for now) by running more fcgiwrap processes and increasing timeouts. When we move the fc-runner to a proper wsgi app rather than old-fashioned CGI this should help further (see https://github.com/ModellingWebLab/fc-runner/issues/6).