### PR TITLE
Clone ontology definitions from dedicated GH repo

### DIFF
--- a/roles/django/tasks/main.yml
+++ b/roles/django/tasks/main.yml
@@ -128,6 +128,12 @@
   become: yes
   become_user: "{{ django_user }}"
 
+- name: Django | Copy ontology definition
+  import_role:
+    name: ontology
+  vars:
+    onto_destination: '{{ django_staticfiles_path }}/js/visualizers/editMetadata/oxford-metadata.rdf'
+
 - name: Django | Ensure we restart every day to avoid git leaking file handles
   cron:
     cron_file: weblab

--- a/roles/fc-backend/tasks/main.yml
+++ b/roles/fc-backend/tasks/main.yml
@@ -100,3 +100,9 @@
       # We can't use a handler, as it's not possible to force a handler to run before the next role's tasks
       command: '{{ fc_virtualenv }}/bin/build_chaste'
       when: code_chaste.changed or code_fc.changed or build_script.changed or fc_exe.stat.exists == False
+
+- name: FC | Copy ontology definition
+  import_role:
+    name: ontology
+  vars:
+    onto_destination: '{{ chaste_root }}/python/pycml/oxford-metadata.rdf'

--- a/roles/ontology/defaults/main.yml
+++ b/roles/ontology/defaults/main.yml
@@ -1,0 +1,16 @@
+# Variables that can be used to configure this role
+
+# Where to clone the ontology definitions from
+onto_repo: https://github.com/ModellingWebLab/ontologies.git
+onto_branch: master
+
+# Where the repository will be checked out
+onto_root: "/opt/ontology"
+
+# Where the main ontology RDF/XML file lives within it
+onto_rdf_xml: "{{ onto_root }}/oxford-metadata.rdf"
+
+# User who should own the ontology files locally
+onto_user: "{{ fc_user }}"
+
+# onto_destination needs to be provided by using role

--- a/roles/ontology/meta/main.yml
+++ b/roles/ontology/meta/main.yml
@@ -1,0 +1,4 @@
+
+dependencies:
+  - role: add_user
+    user_name: "{{ onto_user }}"

--- a/roles/ontology/tasks/main.yml
+++ b/roles/ontology/tasks/main.yml
@@ -1,0 +1,32 @@
+# Tasks to clone the Web Lab ontology definitions and install in the appropriate locations
+
+- name: Ensure folders exist with correct permissions
+  become: yes
+  file:
+    path: '{{ item }}'
+    state: directory
+    owner: '{{ onto_user }}'
+    mode: 0755
+  with_items:
+    - '{{ onto_root }}'
+
+- name: Checkout repository
+  become: yes
+  become_user: '{{ onto_user }}'
+  become_method: sudo
+  git:
+    clone: yes
+    dest: '{{ onto_root }}'
+    repo: '{{ onto_repo }}'
+    version: '{{ onto_branch }}'
+    update: yes
+    force: yes
+
+- name: Copy ontology file to destination
+  become: yes
+  copy:
+    src: '{{ onto_rdf_xml }}'
+    remote_src: yes
+    dest: '{{ onto_destination }}'
+    force: yes
+    mode: 0644


### PR DESCRIPTION
Fixes #28, at least for deployments. Doesn't address documentation for local dev setup!