### PR TITLE
Upgrade default install to Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ vagrant ssh -- -R 8000:localhost:8000
 
 ### Manual virtual machine setup
 
-To get started, create a virtual machine with a default install of Ubuntu 16.04.
+To get started, create a virtual machine with a default install of Ubuntu 18.04.
 Then run
 ```shell
 sudo apt install python3-dev python3-venv
@@ -110,7 +110,7 @@ You only need to use the `superuser` stanzas for the initial deploy.
 
 ## Deploying on a cloud virtual machine
 
-Create a new "Ubuntu Server 16.04 LTS" virtual machine using your preferred cloud provider.
+Create a new "Ubuntu Server 18.04 LTS" virtual machine using your preferred cloud provider.
 We recommend at least 4GB RAM and 40GB disk, e.g. a Standard B2s on Azure.
 How much beyond that you purchase depends on your desired price/performance trade-off.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 
-    # We need Ubuntu 16.04 - now EOL so trying 18.04
+    # We need Ubuntu 18.04
     config.vm.box = "ubuntu/bionic64"
 
     # Needs plugin vagrant-disksize: `vagrant plugin install vagrant-disksize`
@@ -26,6 +26,7 @@ Vagrant.configure("2") do |config|
         ansible.install = true
         ansible.install_mode = "pip"
         ansible.pip_install_cmd = "sudo apt-get install -y python-pip"
+        # The line above is because otherwise Vagrant tries to use pip3 and breaks because OS is Python 2
         ansible.version = "2.8.0"
 
         ansible.playbook = "site.yml"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@
 
 Vagrant.configure("2") do |config|
 
-    # We need Ubuntu 16.04
-    config.vm.box = "ubuntu/xenial64"
+    # We need Ubuntu 16.04 - now EOL so trying 18.04
+    config.vm.box = "ubuntu/bionic64"
 
     # Needs plugin vagrant-disksize: `vagrant plugin install vagrant-disksize`
     config.disksize.size = '40GB'
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
     config.vm.hostname = "weblab.local"
 
     config.vm.provider "virtualbox" do |vb|
-        vb.name = "WebLab"
+        vb.name = "WebLab18"
         vb.memory = "4096"
     end
 
@@ -25,6 +25,7 @@ Vagrant.configure("2") do |config|
         # Install a specific Ansible version with pip
         ansible.install = true
         ansible.install_mode = "pip"
+        ansible.pip_install_cmd = "sudo apt-get install -y python-pip"
         ansible.version = "2.8.0"
 
         ansible.playbook = "site.yml"

--- a/roles/django/tasks/main.yml
+++ b/roles/django/tasks/main.yml
@@ -44,6 +44,16 @@
       notify:
         - restart uwsgi
 
+    - name: Django | Build psycopg2 from source
+      pip:
+        name: psycopg2
+        version: 2.7.7
+        state: present
+        extra_args: '--no-binary psycopg2'
+        virtualenv: '{{ django_virtualenv }}'
+        virtualenv_command: pyvenv
+      become_flags: "-H"
+
     - name: Django | Install project pip requirements
       pip:
         requirements: '{{ django_checkout }}/requirements/base.txt'

--- a/roles/django/vars/main.yml
+++ b/roles/django/vars/main.yml
@@ -14,5 +14,6 @@ postgresql_users:
     # db: "{{ django_db_name }}"
     # role_attr_flags: CREATEDB iff inventory==dev
     # Can't do this here; need to use a task and when: ? Or omit?
+# postgres_users_no_log: false  # Useful for debugging if an error!
 postgresql_locales:
   - 'en_GB.UTF-8'

--- a/roles/fc-backend/defaults/main.yml
+++ b/roles/fc-backend/defaults/main.yml
@@ -14,7 +14,7 @@ fc_project_name: FunctionalCuration
 fc_root: "{{ chaste_root }}/projects/{{ fc_project_name }}"
 chaste_fc_exe: "{{ fc_root }}/apps/src/FunctionalCuration"
 
-chaste_version: 0ff3ad0a2d3bdba18b5e615f6b8d5d93ed1fc7db
+chaste_version: weblab
 
 # FC fitting prototype
 fitting_prototype_repo: https://github.com/ModellingWebLab/chaste-project-fitting-pints.git

--- a/roles/fc-backend/tasks/main.yml
+++ b/roles/fc-backend/tasks/main.yml
@@ -10,7 +10,7 @@
         state: present
     - name: Chaste | Add our apt repo
       apt_repository:
-        repo: deb http://www.cs.ox.ac.uk/chaste/ubuntu xenial/
+        repo: deb http://www.cs.ox.ac.uk/chaste/ubuntu bionic/
         filename: chaste
         state: present
         update_cache: yes

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Install Python
   apt:
-    name: ['python3', 'python3-pip', 'python3-venv', 'python-pip', 'python-virtualenv']
+    name: ['python3', 'python3-pip', 'python3-venv', 'python-pip', 'python-virtualenv', 'python-psycopg2']
     state: present
   become: yes
 


### PR DESCRIPTION
Branch used successfully to upgrade the production server.

We did need to manually remove `/opt/celery/venv` and `/opt/django/venv` first since the change in OS Python version confused the virtual envs that were built from it.