### PR TITLE
Made nginx install use the nginx packages (not the ubuntu ones).

### DIFF
--- a/roles/geerlingguy.nginx/defaults/main.yml
+++ b/roles/geerlingguy.nginx/defaults/main.yml
@@ -6,7 +6,7 @@ nginx_default_release: ""
 nginx_yum_repo_enabled: true
 
 # Use the official Nginx PPA for Ubuntu, and the version to use if so.
-nginx_ppa_use: false
+nginx_ppa_use: true
 nginx_ppa_version: stable
 
 # The name of the nginx package to install.


### PR DESCRIPTION
This means we get a newer version than available on Ubuntu 18.

I first tried upgrading to a newer LTS, but the next LTS has massively reduced Python 2 support, which made that very tricky.
Instead, this is a very small change that worked well when I tested locally.